### PR TITLE
Add initial logging functions

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -28,8 +28,19 @@ class TestVSM(unittest.TestCase):
         process = Popen(cmd, stdin=PIPE, stdout=PIPE)
 
         output, _ = process.communicate(input=input_data.encode(), timeout=2)
+        output_string = output.decode()
 
-        self.assertEqual(output.decode() , expected_output)
+        # strip any prepended timestamp, if it exists
+        output_final = ''
+        for line in output_string.splitlines(True):
+            try:
+                timestamp, remainder = line.split(': ', 1)
+            except ValueError:
+                remainder = line
+
+            output_final = output_final + remainder
+
+        self.assertEqual(output_final , expected_output)
 
     def test_simple0(self):
         input_data = 'transmission_gear = "reverse"'

--- a/vsm
+++ b/vsm
@@ -14,6 +14,7 @@ import sys
 import argparse
 import yaml
 import ast
+import time
 
 LOGIC_REPLACE = {'||': 'or',
                  '&&': 'and',
@@ -21,6 +22,34 @@ LOGIC_REPLACE = {'||': 'or',
                  'false': 'False'}
 
 KEYWORDS = ['condition', 'emit']
+
+start_time_ms = 0
+
+class Log(object):
+    '''
+        Utility class for logging messages
+    '''
+
+    @staticmethod
+    def i(msg, timestamp=False):
+        '''
+            Log an informative (non-error) message
+        '''
+        print(Log.__prepend_timestamp(msg, timestamp))
+
+    @staticmethod
+    def e(msg, timestamp=False):
+        '''
+            Log an error
+        '''
+        print(Log.__prepend_timestamp(msg, timestamp), file=sys.stderr)
+
+    @staticmethod
+    def __prepend_timestamp(msg, timestamp):
+        if(not timestamp):
+            return msg
+
+        return '{}: {}'.format(get_runtime(), msg)
 
 class State(object):
     '''
@@ -70,7 +99,7 @@ class State(object):
                     action = ast.parse(action).body[0]
 
                 else:
-                    print("Unhandled keyword {}".format(word))
+                    Log.e("Unhandled keyword {}".format(word))
 
             ifnode = ast.If(condition.value, [action], [])
             ast_module = ast.Module([ifnode])
@@ -118,7 +147,7 @@ class State(object):
 
 
 def emit(signal, value):
-    print('{} = {}'.format(signal, value))
+    Log.i('{} = {}'.format(signal, value))
 
 
 def process(state, signal, value):
@@ -164,8 +193,12 @@ def run(state):
         else:
             process(state, line, None)
 
+def get_runtime():
+    return round(time.perf_counter() * 1000 - start_time_ms)
 
 if __name__ == "__main__":
+    start_time_ms = round(time.perf_counter() * 1000)
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--initial-state', type=str,
                         help='Initial state, yaml file', required=False)


### PR DESCRIPTION
These currently just output directly to stdout or stderr but we will be
redirecting them to the logger process in future work.

The methods take an optional "timestamp" boolean parameter. If true, the
message will be prepended by the runtime (relative time since invocation)
in milliseconds.